### PR TITLE
S1/cpt field

### DIFF
--- a/app/Post_Types/Archive_Item/AdminModifications.php
+++ b/app/Post_Types/Archive_Item/AdminModifications.php
@@ -21,27 +21,23 @@ class AdminModifications {
 	}
 
 	function active_field_setup(  ) {
-		// get active fields
-		$field_query = new \WP_Query( array(
-			'post_type' => Diviner_Field::NAME,
-			'meta_query'=> array(
-				array(
-					'key'     => Helper::get_real_field_name(FieldPostMeta::FIELD_ACTIVE ),
-					'value'   => FieldPostMeta::FIELD_CHECKBOX_VALUE
-				),
+		$meta_query = array(
+			array(
+				'key'     => Helper::get_real_field_name(FieldPostMeta::FIELD_ACTIVE ),
+				'value'   => FieldPostMeta::FIELD_CHECKBOX_VALUE
 			),
-		) );
-		// call setup on active fields
-		while( $field_query->have_posts() ) : $field_query->the_post();
-			$field_type = carbon_get_the_post_meta( FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables' );
-			$field = Diviner_Field::get_class( $field_type );
-			$static_call_name = sprintf(
-				'%s::setup',
-				$field
-			);
-			call_user_func($static_call_name);
-		endwhile;
-		wp_reset_postdata();
+		);
+		$args = array(
+			'fields' => 'ids',
+			'post_type' => Diviner_Field::NAME,
+			'meta_query' => $meta_query
+		);
+		$posts_ids = get_posts($args);
+		foreach($posts_ids as $post_id) {
+			$field_type = carbon_get_post_meta($post_id, FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables');
+			$field = Diviner_Field::get_class($field_type);
+			call_user_func(array($field, 'setup'), $post_id);
+		}
 	}
 
 	function manage_diviner_archive_item_posts_custom_column( $colname, $cptid  ) {

--- a/app/Post_Types/Archive_Item/AdminModifications.php
+++ b/app/Post_Types/Archive_Item/AdminModifications.php
@@ -3,6 +3,10 @@
 namespace Diviner\Post_Types\Archive_Item;
 
 use function Tonik\Theme\App\config;
+use Diviner\Post_Types\Diviner_Field\Diviner_Field;
+use Diviner\Post_Types\Diviner_Field\PostMeta as FieldPostMeta;
+use Diviner\CarbonFields\Helper;
+use Diviner\CarbonFields\Errors\UndefinedType;
 
 class AdminModifications {
 
@@ -13,6 +17,37 @@ class AdminModifications {
 		add_filter( 'admin_body_class', array( &$this,'admin_body_class') );
 		add_filter( 'manage_edit-diviner_archive_item_columns', [ $this, 'archival_item_columns' ] );
 		add_action( 'manage_diviner_archive_item_posts_custom_column', [ $this, 'manage_diviner_archive_item_posts_custom_column' ], 10, 2 );
+		add_action( 'carbon_fields_register_fields', [ $this, 'carbon_fields_register_fields' ], 3, 0 );
+
+	}
+
+	function carbon_fields_register_fields(  ) {
+		$field_query = new \WP_Query( array(
+			'post_type' => Diviner_Field::NAME,
+			'meta_query'=> array(
+				array(
+					'key'     => Helper::get_real_field_name(FieldPostMeta::FIELD_ACTIVE ),
+					'value'   => FieldPostMeta::FIELD_CHECKBOX_VALUE
+				),
+			),
+		) );
+		$dyn_fields = [];
+		// $type = carbon_get_post_meta( $cptid, Post_Meta::FIELD_TYPE );
+		while( $field_query->have_posts() ) : $field_query->the_post();
+			// add fields
+			// $type = $this->get_class( get_post() );
+			// if ( $type ) {
+			//	$dyn_fields[] = $this->get_field( $type );
+			// }
+			$field_type = carbon_get_the_post_meta( FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables' );
+			$field = Diviner_Field::get_class( $field_type );
+			$static_call_name = sprintf(
+				'%s::setup',
+				$field
+			);
+			call_user_func($static_call_name);
+		endwhile;
+		wp_reset_postdata();
 	}
 
 	function manage_diviner_archive_item_posts_custom_column( $colname, $cptid  ) {

--- a/app/Post_Types/Archive_Item/AdminModifications.php
+++ b/app/Post_Types/Archive_Item/AdminModifications.php
@@ -17,11 +17,11 @@ class AdminModifications {
 		add_filter( 'admin_body_class', array( &$this,'admin_body_class') );
 		add_filter( 'manage_edit-diviner_archive_item_columns', [ $this, 'archival_item_columns' ] );
 		add_action( 'manage_diviner_archive_item_posts_custom_column', [ $this, 'manage_diviner_archive_item_posts_custom_column' ], 10, 2 );
-		add_action( 'carbon_fields_register_fields', [ $this, 'carbon_fields_register_fields' ], 3, 0 );
-
+		add_action( 'carbon_fields_register_fields', [ $this, 'active_field_setup' ], 3, 0 );
 	}
 
-	function carbon_fields_register_fields(  ) {
+	function active_field_setup(  ) {
+		// get active fields
 		$field_query = new \WP_Query( array(
 			'post_type' => Diviner_Field::NAME,
 			'meta_query'=> array(
@@ -31,14 +31,8 @@ class AdminModifications {
 				),
 			),
 		) );
-		$dyn_fields = [];
-		// $type = carbon_get_post_meta( $cptid, Post_Meta::FIELD_TYPE );
+		// call setup on active fields
 		while( $field_query->have_posts() ) : $field_query->the_post();
-			// add fields
-			// $type = $this->get_class( get_post() );
-			// if ( $type ) {
-			//	$dyn_fields[] = $this->get_field( $type );
-			// }
 			$field_type = carbon_get_the_post_meta( FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables' );
 			$field = Diviner_Field::get_class( $field_type );
 			$static_call_name = sprintf(
@@ -124,9 +118,6 @@ class AdminModifications {
 		);
 
 		remove_submenu_page( 'edit.php?post_type=diviner_archive_item', 	'post-new.php?post_type=diviner_archive_item' );
-
-		//add_menu_page( 'Diviner Fields', 'Manage	 Diviner Fields', 'manage_options', 'diviner-manage-fields', array( &$this,'rc_scd_create_dashboard'), 'dashicons-admin-generic', 30 );
-
 	}
 
 }

--- a/app/Post_Types/Archive_Item/Post_Meta.php
+++ b/app/Post_Types/Archive_Item/Post_Meta.php
@@ -158,9 +158,14 @@ class Post_Meta {
 		// $type = carbon_get_post_meta( $cptid, Post_Meta::FIELD_TYPE );
 		while( $field_query->have_posts() ) : $field_query->the_post();
 			// add fields
-			$type = $this->get_class( get_post() );
+			$field_type = carbon_get_the_post_meta( FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables' );
+			$type = Diviner_Field::get_class( $field_type );
 			if ( $type ) {
-				$dyn_fields[] = $this->get_field( $type );
+				$field_rendered = $this->get_field( $type );
+				if ( ! empty( $field_rendered ) ) {
+					$dyn_fields[] = $field_rendered;
+				}
+
 			}
 		endwhile;
 		wp_reset_postdata();

--- a/app/Post_Types/Archive_Item/Post_Meta.php
+++ b/app/Post_Types/Archive_Item/Post_Meta.php
@@ -129,21 +129,42 @@ class Post_Meta {
 		return $map[$field_type];
 	}
 
-	public function get_field($type) {
-		$id = carbon_get_the_post_meta( FieldPostMeta::FIELD_ID );
-		$label = carbon_get_the_post_meta( FieldPostMeta::FIELD_LABEL_TITLE );
-		$helper = carbon_get_the_post_meta( FieldPostMeta::FIELD_ADMIN_HELPER_TEXT);
-
-		// return call_user_func([$type, 'render']);
-
-		$static_call_name = sprintf(
-			'%s::render',
-			$type
-		);
-		return call_user_func($static_call_name, $id, $label, $helper);
+	public function get_field( $post_id, $type ) {
+		$id = carbon_get_post_meta( $post_id, FieldPostMeta::FIELD_ID );
+		$label = carbon_get_post_meta( $post_id, FieldPostMeta::FIELD_LABEL_TITLE );
+		$helper = carbon_get_post_meta( $post_id, FieldPostMeta::FIELD_ADMIN_HELPER_TEXT);
+		return call_user_func( array($type, 'render'), $post_id, $id, $label, $helper);
 	}
 
 	public function add_dynamic_fields(){
+		$meta_query = array(
+			array(
+				'key'     => Helper::get_real_field_name(FieldPostMeta::FIELD_ACTIVE ),
+				'value'   => FieldPostMeta::FIELD_CHECKBOX_VALUE
+			),
+		);
+		$args = array(
+			'fields' => 'ids',
+			'post_type' => Diviner_Field::NAME,
+			'meta_query' => $meta_query
+		);
+		$posts_ids = get_posts($args);
+
+		foreach($posts_ids as $post_id) {
+			$field_type = carbon_get_post_meta($post_id, FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables');
+			$type = Diviner_Field::get_class( $field_type );
+			// call_user_func(array($field, 'setup'), $post_id);
+			if ( $type ) {
+				$field_rendered = $this->get_field( $post_id,  $type );
+				if ( ! empty( $field_rendered ) ) {
+					$dyn_fields[] = $field_rendered;
+				}
+
+			}
+		}
+
+
+		/*
 		$field_query = new \WP_Query( array(
 			'post_type' => Diviner_Field::NAME,
 			'meta_query'=> array(
@@ -161,7 +182,7 @@ class Post_Meta {
 			$field_type = carbon_get_the_post_meta( FieldPostMeta::FIELD_TYPE, 'carbon_fields_container_field_variables' );
 			$type = Diviner_Field::get_class( $field_type );
 			if ( $type ) {
-				$field_rendered = $this->get_field( $type );
+				$field_rendered = $this->get_field( get_the_ID(),  $type );
 				if ( ! empty( $field_rendered ) ) {
 					$dyn_fields[] = $field_rendered;
 				}
@@ -169,6 +190,7 @@ class Post_Meta {
 			}
 		endwhile;
 		wp_reset_postdata();
+		*/
 
 		$dyn_fields_container = Container::make( 'post_meta', 'Additional Fields' )
 			->where( 'post_type', '=', Archive_Item::NAME )

--- a/app/Post_Types/Diviner_Field/Diviner_Field.php
+++ b/app/Post_Types/Diviner_Field/Diviner_Field.php
@@ -53,13 +53,11 @@ class Diviner_Field {
 			Text_Field::NAME        => Text_Field::class,
 			Date_Field::NAME        => Date_Field::class,
 			CPT_Field::NAME         => CPT_Field::class,
+			Related_Field::NAME     => Related_Field::class,
 		];
-
 		if( !array_key_exists( $field_type, $map ) ){
-			// developer-land exception, let's make it clear
 			throw UndefinedType("{$field_type} is not a valid field type");
 		}
-
 		return $map[$field_type];
 	}
 

--- a/app/Post_Types/Diviner_Field/Diviner_Field.php
+++ b/app/Post_Types/Diviner_Field/Diviner_Field.php
@@ -3,6 +3,13 @@
 
 namespace Diviner\Post_Types\Diviner_Field;
 
+use Diviner\Post_Types\Diviner_Field\Types\Text_Field;
+use Diviner\Post_Types\Diviner_Field\Types\Date_Field;
+use Diviner\Post_Types\Diviner_Field\Types\Taxonomy_Field;
+use Diviner\Post_Types\Diviner_Field\Types\CPT_Field;
+use Diviner\Post_Types\Diviner_Field\Types\Select_Field;
+use Diviner\Post_Types\Diviner_Field\Types\Related_Field;
+use Diviner\CarbonFields\Errors\UndefinedType;
 
 class Diviner_Field {
 
@@ -40,4 +47,20 @@ class Diviner_Field {
 			]
 		];
 	}
+
+	static public function get_class( $field_type ) {
+		$map = [
+			Text_Field::NAME        => Text_Field::class,
+			Date_Field::NAME        => Date_Field::class,
+			CPT_Field::NAME         => CPT_Field::class,
+		];
+
+		if( !array_key_exists( $field_type, $map ) ){
+			// developer-land exception, let's make it clear
+			throw UndefinedType("{$field_type} is not a valid field type");
+		}
+
+		return $map[$field_type];
+	}
+
 }

--- a/app/Post_Types/Diviner_Field/PostMeta.php
+++ b/app/Post_Types/Diviner_Field/PostMeta.php
@@ -32,6 +32,10 @@ class PostMeta {
 
 	const FIELD_IS_DEFAULT     = 'div_field_default';
 
+	const FIELD_CPT_LABEL = 'div_field_cpt_label';
+	const FIELD_CPT_ID = 'div_field_cpt_id';
+	const FIELD_CPT_SLUG = 'div_field_cpt_slug';
+
 	const FIELD_TAXONOMY_TYPE = 'div_field_taxonomy_type';
 	const FIELD_TAXONOMY_TYPE_TAG = 'div_field_taxonomy_type_tag';
 	const FIELD_TAXONOMY_TYPE_CATEGORY= 'div_field_taxonomy_type_category';
@@ -100,6 +104,27 @@ class PostMeta {
 				$this->get_field_taxonomy_type(),
 			))
 			->set_priority( 'low' );
+
+		$this->container = Container::make( 'post_meta', 'Custom Post Type Field Variables' )
+			->where( 'post_type', '=', Diviner_Field::NAME )
+			->add_fields( array(
+				$this->get_field_CPT_ID(),
+				$this->get_field_CPT_Label(),
+				$this->get_field_CPT_SLUG(),
+			))
+			->set_priority( 'low' );
+	}
+
+	public function get_field_CPT_ID() {
+		return Field::make( 'text', self::FIELD_CPT_ID, 'Custom Post Type ID (use only lower case with underscores)' );
+	}
+
+	public function get_field_CPT_Label() {
+		return Field::make( 'text', self::FIELD_CPT_LABEL, 'Custom Post Label' );
+	}
+
+	public function get_field_CPT_SLUG() {
+		return Field::make( 'text', self::FIELD_CPT_SLUG, 'Custom Post Label (use only lower case with dashes)' );
 	}
 
 	public function get_field_taxonomy_type() {

--- a/app/Post_Types/Diviner_Field/Types/CPT_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/CPT_Field.php
@@ -20,22 +20,19 @@ class CPT_Field extends FieldType {
 		$field_label = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_LABEL );
 		$field_slug = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_SLUG );
 
+		// default values
 		if ( empty( $field_id ) ) {
-			// $field_id = 'diviner_cpt_id';
-			// set up based on field ID
 			$field_id = sprintf('div_cpt_name_%s', get_the_ID() );
 		}
-
 		if ( empty( $field_label ) ) {
 			$field_label = 'Diviner Custom Post Type';
 		}
 		$field_labels = sprintf('%ss', $field_label);
-
 		if ( empty( $field_slug ) ) {
-			// $field_slug = 'diviner-cpt';
 			$field_slug = sanitize_title( $field_label );
 		}
-
+		// ToDo: make some of the other cpt labels/config editable
+		// has_archive etc etc
 		// registering the custom post type
 		$args = [
 			'public'             => true,
@@ -50,7 +47,6 @@ class CPT_Field extends FieldType {
 			'menu_position'      => null,
 			'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt' ),
 			'map_meta_cap'       => true,
-			// 'has_archive'     => _x( 'archive-item', 'post archive slug', 'tribe' ),
 		];
 		$labels = [
 			'labels' => [

--- a/app/Post_Types/Diviner_Field/Types/CPT_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/CPT_Field.php
@@ -4,10 +4,6 @@
 namespace Diviner\Post_Types\Diviner_Field\Types;
 
 use Carbon_Fields\Field;
-use Carbon_Fields\Container;
-
-use Diviner\Post_Types\Archive_Item\Archive_Item;
-use Diviner\Post_Types\Diviner_Field\Diviner_Field;
 use Diviner\Post_Types\Diviner_Field\PostMeta as FieldPostMeta;
 
 class CPT_Field extends FieldType {
@@ -25,16 +21,19 @@ class CPT_Field extends FieldType {
 		$field_slug = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_SLUG );
 
 		if ( empty( $field_id ) ) {
-			$field_id = 'diviner_cpt_id';
+			// $field_id = 'diviner_cpt_id';
+			// set up based on field ID
+			$field_id = sprintf('div_cpt_name_%s', get_the_ID() );
 		}
 
 		if ( empty( $field_label ) ) {
-			$field_label = 'Diviner CPT';
+			$field_label = 'Diviner Custom Post Type';
 		}
 		$field_labels = sprintf('%ss', $field_label);
 
 		if ( empty( $field_slug ) ) {
-			$field_slug = 'diviner-cpt';
+			// $field_slug = 'diviner-cpt';
+			$field_slug = sanitize_title( $field_label );
 		}
 
 		// registering the custom post type
@@ -64,7 +63,7 @@ class CPT_Field extends FieldType {
 		$args = wp_parse_args( $args, $labels );
 		register_post_type( $field_id, $args );
 
-		// set up additional field?? Unnecessary for now
+		// You could set up additional field here...
 		/*
 		$container = Container::make( 'post_meta', 'Creator Fields' )
 			->where( 'post_type', '=', Diviner_Field::NAME )
@@ -77,8 +76,6 @@ class CPT_Field extends FieldType {
 	}
 
 	static public function render( $id, $field_label, $helper = '') {
-		// $field =  Field::make( static::TYPE, $id, $field_label );
-
 		$field_cpt_id = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_ID );
 		if ( empty($field_cpt_id) ) {
 			return null;

--- a/app/Post_Types/Diviner_Field/Types/CPT_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/CPT_Field.php
@@ -4,23 +4,97 @@
 namespace Diviner\Post_Types\Diviner_Field\Types;
 
 use Carbon_Fields\Field;
+use Carbon_Fields\Container;
+
+use Diviner\Post_Types\Archive_Item\Archive_Item;
+use Diviner\Post_Types\Diviner_Field\Diviner_Field;
+use Diviner\Post_Types\Diviner_Field\PostMeta as FieldPostMeta;
 
 class CPT_Field extends FieldType {
 
 	const NAME = 'diviner_cpt_field';
 	const TITLE = 'CPT Field';
+	const TYPE = 'association';
 
-	static public function hook () {
+	const FIELD_CPT_TYPE_FIELD_ID = 'diviner_cpt_type_field';
+
+	static public function setup () {
+		// set up CPT
+		$field_id = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_ID );
+		$field_label = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_LABEL );
+		$field_slug = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_SLUG );
+
+		if ( empty( $field_id ) ) {
+			$field_id = 'diviner_cpt_id';
+		}
+
+		if ( empty( $field_label ) ) {
+			$field_label = 'Diviner CPT';
+		}
+		$field_labels = sprintf('%ss', $field_label);
+
+		if ( empty( $field_slug ) ) {
+			$field_slug = 'diviner-cpt';
+		}
+
 		// registering the custom post type
+		$args = [
+			'public'             => true,
+			'publicly_queryable' => true,
+			'show_ui'            => true,
+			'show_in_menu'       => true,
+			'query_var'          => true,
+			'rewrite'            => array( 'slug' => $field_slug ),
+			'capability_type'    => 'post',
+			'has_archive'        => true,
+			'hierarchical'       => false,
+			'menu_position'      => null,
+			'supports'           => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt' ),
+			'map_meta_cap'       => true,
+			// 'has_archive'     => _x( 'archive-item', 'post archive slug', 'tribe' ),
+		];
+		$labels = [
+			'labels' => [
+				'singular'     => $field_label,
+				'plural'       => $field_labels,
+				'name'         => $field_labels,
+				'add_new_item' => sprintf( 'Add New %s', $field_label ),
+			]
+		];
+		$args = wp_parse_args( $args, $labels );
+		register_post_type( $field_id, $args );
+
+		// set up additional field?? Unnecessary for now
+		/*
+		$container = Container::make( 'post_meta', 'Creator Fields' )
+			->where( 'post_type', '=', Diviner_Field::NAME )
+			->add_fields( array(
+				Field::make( 'text', self::FIELD_CPT_TYPE_FIELD_ID, 'CPT Type Field ID' )
+			))
+			->set_priority( 'default' );
+		*/
+
 	}
 
 	static public function render( $id, $field_label, $helper = '') {
-		$field =  Field::make( static::TYPE, $id, $field_label );
+		// $field =  Field::make( static::TYPE, $id, $field_label );
+
+		$field_cpt_id = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_ID );
+		if ( empty($field_cpt_id) ) {
+			return null;
+		}
+
+		$field = Field::make(static::TYPE, $id, $field_label)
+			->set_types(array(
+				array(
+					'type' => 'post',
+					'post_type' => $field_cpt_id,
+				),
+			));
+
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);
 		}
 		return $field;
 	}
-
-
 }

--- a/app/Post_Types/Diviner_Field/Types/CPT_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/CPT_Field.php
@@ -14,15 +14,15 @@ class CPT_Field extends FieldType {
 
 	const FIELD_CPT_TYPE_FIELD_ID = 'diviner_cpt_type_field';
 
-	static public function setup () {
+	static public function setup ( $post_id ) {
 		// set up CPT
-		$field_id = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_ID );
-		$field_label = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_LABEL );
-		$field_slug = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_SLUG );
+		$field_id = carbon_get_post_meta( $post_id, FieldPostMeta::FIELD_CPT_ID );
+		$field_label = carbon_get_post_meta( $post_id, FieldPostMeta::FIELD_CPT_LABEL );
+		$field_slug = carbon_get_post_meta( $post_id, FieldPostMeta::FIELD_CPT_SLUG );
 
 		// default values
 		if ( empty( $field_id ) ) {
-			$field_id = sprintf('div_cpt_name_%s', get_the_ID() );
+			$field_id = sprintf('div_cpt_name_%s', $post_id );
 		}
 		if ( empty( $field_label ) ) {
 			$field_label = 'Diviner Custom Post Type';
@@ -59,6 +59,7 @@ class CPT_Field extends FieldType {
 		$args = wp_parse_args( $args, $labels );
 		register_post_type( $field_id, $args );
 
+
 		// You could set up additional field here...
 		/*
 		$container = Container::make( 'post_meta', 'Creator Fields' )
@@ -71,8 +72,8 @@ class CPT_Field extends FieldType {
 
 	}
 
-	static public function render( $id, $field_label, $helper = '') {
-		$field_cpt_id = carbon_get_the_post_meta( FieldPostMeta::FIELD_CPT_ID );
+	static public function render( $post_id, $id, $field_label, $helper = '') {
+		$field_cpt_id = carbon_get_post_meta( $post_id,FieldPostMeta::FIELD_CPT_ID );
 		if ( empty($field_cpt_id) ) {
 			return null;
 		}

--- a/app/Post_Types/Diviner_Field/Types/Date_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/Date_Field.php
@@ -11,7 +11,7 @@ class Date_Field extends FieldType  {
 	const TITLE = 'Date Field';
 	const TYPE = 'date';
 
-	static public function render( $id, $field_label, $helper = '') {
+	static public function render( $post_id, $id, $field_label, $helper = '') {
 		$field =  Field::make( static::TYPE, $id, $field_label );
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);

--- a/app/Post_Types/Diviner_Field/Types/FieldType.php
+++ b/app/Post_Types/Diviner_Field/Types/FieldType.php
@@ -12,4 +12,7 @@ abstract class FieldType implements iField {
 		return $field;
 	}
 
+	static public function setup() {
+
+	}
 }

--- a/app/Post_Types/Diviner_Field/Types/FieldType.php
+++ b/app/Post_Types/Diviner_Field/Types/FieldType.php
@@ -4,7 +4,7 @@ namespace Diviner\Post_Types\Diviner_Field\Types;
 
 abstract class FieldType implements iField {
 
-	static public function render( $id, $field_label, $helper = '') {
+	static public function render( $post_id, $id, $field_label, $helper = '') {
 		$field =  Field::make( static::TYPE, $id, $field_label );
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);
@@ -12,7 +12,12 @@ abstract class FieldType implements iField {
 		return $field;
 	}
 
-	static public function setup() {
+	/**
+	 * No operation method for setting up field. Extend if necessary
+	 *
+	 * @param  int $post_id Post Id of field to set up.
+	 */
+	static public function setup( $post_id ) {
 
 	}
 }

--- a/app/Post_Types/Diviner_Field/Types/Related_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/Related_Field.php
@@ -11,7 +11,7 @@ class Related_Field extends FieldType  {
 	const TITLE = 'Related Items Field';
 	const TYPE = 'association';
 
-	static public function render( $id, $field_label, $helper = '') {
+	static public function render( $post_id, $id, $field_label, $helper = '') {
 
 		$field = Field::make(static::TYPE, $id, $field_label)
 			->set_types(array(

--- a/app/Post_Types/Diviner_Field/Types/Related_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/Related_Field.php
@@ -1,19 +1,26 @@
 <?php
 
-
 namespace Diviner\Post_Types\Diviner_Field\Types;
 
-use Diviner\Post_Types\Diviner_Field\Types\FieldType;
+use Diviner\Post_Types\Archive_Item\Archive_Item;
 use Carbon_Fields\Field;
 
 class Related_Field extends FieldType  {
 
-	const NAME = 'diviner_elated_field';
+	const NAME = 'diviner_related_field';
 	const TITLE = 'Related Items Field';
-	const TYPE = 'related';
+	const TYPE = 'association';
 
 	static public function render( $id, $field_label, $helper = '') {
-		$field =  Field::make( static::TYPE, $id, $field_label );
+
+		$field = Field::make(static::TYPE, $id, $field_label)
+			->set_types(array(
+				array(
+					'type' => 'post',
+					'post_type' => Archive_Item::NAME,
+				),
+			));
+
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);
 		}

--- a/app/Post_Types/Diviner_Field/Types/Select_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/Select_Field.php
@@ -12,7 +12,7 @@ class Select_Field extends FieldType {
 	const TITLE = 'Select Field';
 	const TYPE = 'select';
 
-	static public function render( $id, $field_label, $helper = '') {
+	static public function render( $post_id, $id, $field_label, $helper = '') {
 		$field =  Field::make( static::TYPE, $id, $field_label );
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);

--- a/app/Post_Types/Diviner_Field/Types/Taxonomy_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/Taxonomy_Field.php
@@ -12,7 +12,7 @@ class Taxonomy_Field extends FieldType {
 	const TITLE = 'Taxonomy Field';
 	const TYPE = 'taxonomy';
 
-	static public function render( $id, $field_label, $helper = '') {
+	static public function render( $post_id, $id, $field_label, $helper = '') {
 		$field =  Field::make( static::TYPE, $id, $field_label );
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);

--- a/app/Post_Types/Diviner_Field/Types/Text_Field.php
+++ b/app/Post_Types/Diviner_Field/Types/Text_Field.php
@@ -12,7 +12,7 @@ class Text_Field extends FieldType {
 	const TITLE = 'Text Field';
 	const TYPE = 'text';
 
-	static public function render( $id, $field_label, $helper = '') {
+	static public function render( $post_id, $id, $field_label, $helper = '') {
 		$field =  Field::make( static::TYPE, $id, $field_label );
 		if ( ! empty( $helper ) ) {
 			$field->help_text($helper);

--- a/app/Post_Types/Diviner_Field/Types/iField.php
+++ b/app/Post_Types/Diviner_Field/Types/iField.php
@@ -4,6 +4,8 @@ namespace Diviner\Post_Types\Diviner_Field\Types;
 
 interface iField {
 
-	static public function render( $id, $field_label, $helper = '');
+	static public function render( $post_id, $id, $field_label, $helper = '');
+
+	static public function setup( $post_id );
 
 }

--- a/resources/assets/sass/admin/_diviner-field.scss
+++ b/resources/assets/sass/admin/_diviner-field.scss
@@ -47,3 +47,10 @@
 	}
 }
 
+#carbon_fields_container_custom_post_type_field_variables {
+	display: none !important;
+	.post-field-type--diviner_cpt_field & {
+		display: block !important;
+	}
+}
+

--- a/resources/assets/sass/admin/_diviner-field.scss
+++ b/resources/assets/sass/admin/_diviner-field.scss
@@ -54,3 +54,9 @@
 	}
 }
 
+#minor-publishing {
+	.post-edit--diviner_field & {
+		display: none;
+	}
+}
+

--- a/resources/templates/partials/searchform.tpl.php
+++ b/resources/templates/partials/searchform.tpl.php
@@ -5,7 +5,7 @@
             type="text"
             name="s"
             value="<?php the_search_query(); ?>"
-            placeholder="<?= __('Searching for...', 'ncpr-diviner' ?>"
+            placeholder="<?= __('Searching for...', 'ncpr-diviner'); ?>"
         >
     </label>
 


### PR DESCRIPTION
Build out of CPT field and Related Items field. The CPT field required that I call a `setup` function per each field. For the CPT, this builds out the custom post type. Related Items is a more straightforward field build out because carbon fields already has the convenient "association" field type.